### PR TITLE
Fixed SIRI 2.0 REST Req/Resp: use http get

### DIFF
--- a/src/main/java/no/rutebanken/anshar/routes/siri/Siri20ToSiriRS20RequestResponse.java
+++ b/src/main/java/no/rutebanken/anshar/routes/siri/Siri20ToSiriRS20RequestResponse.java
@@ -64,7 +64,7 @@ public class Siri20ToSiriRS20RequestResponse extends SiriSubscriptionRouteBuilde
             .setExchangePattern(ExchangePattern.InOut) // Make sure we wait for a response
             .removeHeaders("CamelHttp*") // Remove any incoming HTTP headers as they interfere with the outgoing definition
             .setHeader(Exchange.CONTENT_TYPE, constant(subscriptionSetup.getContentType())) // Necessary when talking to Microsoft web services
-            .setHeader(Exchange.HTTP_METHOD, constant(HttpMethods.POST))
+            .setHeader(Exchange.HTTP_METHOD, constant(HttpMethods.GET))
             .process(addCustomHeaders())
             .to("log:request:" + getClass().getSimpleName() + "?showAll=true&multiline=true")
             .doTry()


### PR DESCRIPTION
Use HTTP GET method (rather than POST) for SIRI REST request/response subscriptions 