### PR TITLE
Allow setting of OperatorRef in Siri-SX subscription request

### DIFF
--- a/src/main/java/no/rutebanken/anshar/routes/siri/helpers/SiriObjectFactory.java
+++ b/src/main/java/no/rutebanken/anshar/routes/siri/helpers/SiriObjectFactory.java
@@ -288,6 +288,16 @@ public class SiriObjectFactory {
                     sxRequest.setVehicleRef((VehicleRef) next);
                 }
             }
+            if (filterMap.containsKey(OperatorRefStructure.class)) {
+                Set<Object> operatorRefs = filterMap.get(OperatorRefStructure.class);
+                for (Object operatorRef : operatorRefs) {
+                    if (operatorRef instanceof String) {
+                        var refStructure = new OperatorRefStructure();
+                        refStructure.setValue((String) operatorRef);
+                        sxRequest.setOperatorRef(refStructure);
+                    }
+                }
+            }
         }
 
         SituationExchangeSubscriptionStructure sxSubscriptionReq = new SituationExchangeSubscriptionStructure();

--- a/src/main/resources/subscriptions-example.yml
+++ b/src/main/resources/subscriptions-example.yml
@@ -95,7 +95,8 @@ anshar:
       requestorRef: anshar-example-${random.uuid}
       durationOfSubscriptionHours: 1680
       mappingAdapterId: entur
-      filterPresets:
+      filterMap:
+        uk.org.siri.siri21.OperatorRefStructure: "AN_OPERATOR"
       idMappingPrefixes:
       active: false
       

--- a/src/test/java/no/rutebanken/anshar/siri/SiriObjectFactoryTest.java
+++ b/src/test/java/no/rutebanken/anshar/siri/SiriObjectFactoryTest.java
@@ -15,10 +15,13 @@
 
 package no.rutebanken.anshar.siri;
 
+import java.util.Map;
+import java.util.Set;
 import no.rutebanken.anshar.routes.siri.helpers.SiriObjectFactory;
 import no.rutebanken.anshar.subscription.SiriDataType;
 import no.rutebanken.anshar.subscription.SubscriptionSetup;
 import org.junit.jupiter.api.Test;
+import uk.org.siri.siri21.OperatorRefStructure;
 import uk.org.siri.siri21.EstimatedTimetableRequestStructure;
 import uk.org.siri.siri21.EstimatedTimetableSubscriptionStructure;
 import uk.org.siri.siri21.Siri;
@@ -101,6 +104,13 @@ public class SiriObjectFactoryTest {
                 SubscriptionSetup.SubscriptionMode.REQUEST_RESPONSE,
                 UUID.randomUUID().toString());
 
+        final String operatorName = "AN_OPERATOR";
+        var operatorRef = new OperatorRefStructure();
+        operatorRef.setValue(operatorName);
+        subscriptionSetup.setFilterMap(
+                Map.of(OperatorRefStructure.class, Set.of(operatorRef))
+        );
+
         Siri sxSubscriptionRequest = SiriObjectFactory.createSubscriptionRequest(subscriptionSetup);
         assertNotNull(sxSubscriptionRequest.getSubscriptionRequest());
 
@@ -125,8 +135,8 @@ public class SiriObjectFactoryTest {
             "Initial terminationtime has not been calculated correctly"
         );
 
-
-
+        var ref = subscription.getSituationExchangeRequest().getOperatorRef().getValue();
+        assertEquals(ref, operatorName);
     }
 
     @Test


### PR DESCRIPTION
For a Siri-SX subscription request I needed to set the `<OperatorRef>` field.

I found an example of how to do it in the Siri-ET code and tried to convert it to the Siri-SX one.

However, I'm not sure if I fully understood how these `filterMaps` are supposed to be used.

@lassetyr Can you check the config example if this is correct?