### PR TITLE
Reduce logging in splitDataForProcessing route

### DIFF
--- a/src/main/java/no/rutebanken/anshar/routes/messaging/MessagingRoute.java
+++ b/src/main/java/no/rutebanken/anshar/routes/messaging/MessagingRoute.java
@@ -154,16 +154,17 @@ public class MessagingRoute extends RestRouteBuilder {
                     .choice()
                         .when(header(INTERNAL_PUBLISH_TO_KAFKA_FOR_APC_ENRICHMENT).isEqualTo(Boolean.TRUE))
                         .removeHeader(INTERNAL_PUBLISH_TO_KAFKA_FOR_APC_ENRICHMENT)
-                        .log("Sending data to enrichment topic")
+                        .log(LoggingLevel.DEBUG, "Sending data to enrichment topic")
                         .to("direct:anshar.enrich.siri.et")
                     .endChoice()
                     .otherwise()
-                        .log("Sending split data to topic ${header.target_topic}")
+                        .log(LoggingLevel.DEBUG, "Sending split data to topic ${header.target_topic}")
                         .to("xslt-saxon:xsl/split.xsl")
                         .split().tokenizeXML("Siri").streaming()
                         .to("direct:compress.jaxb")
                         .toD("${header.target_topic}")
                     .end()
+                    .routeId("split.data.for.processing")
             ;
         } else {
 


### PR DESCRIPTION
Reduce logging to DEBUG level in splitDataForProcessing route. Also adding routeId so logging levels can be configured for the route (otherwise the logger name is dynamic/autogenerated)