### PR TITLE
Harmonize Renovate onto shared config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "github>entur/ror-renovate-config"
   ]
 }


### PR DESCRIPTION
## Harmonize onto the shared Renovate config

Replaces the bare `config:base` preset (a deprecated Renovate default) with the
team's shared preset `github>entur/ror-renovate-config`, matching the ~40 other
repos in the team.

No local rules were dropped — the previous config had none beyond `config:base`.
`master` is this repo's default branch, so no `baseBranch` override is needed.



---
_Part of the team-wide Renovate harmonization. Depends on the shared-config update **entur/ror-renovate-config#12** (merge that first)._