### PR TITLE
Filter out VehicleActivities with invalid location

### DIFF
--- a/src/main/java/no/rutebanken/anshar/data/VehicleActivities.java
+++ b/src/main/java/no/rutebanken/anshar/data/VehicleActivities.java
@@ -368,10 +368,12 @@ public class VehicleActivities extends SiriRepository<VehicleActivityStructure> 
                         resolveContentMetrics(activity, expiration);
                         if (expiration > 0 && isNewer && locationValid) {
                             changes.put(key, activity);
-                        } else if (!locationValid) {
-                            invalidLocationCounter.incrementAndGet();
-                        } else {
+                        }
+                        if (!(expiration > 0 && isNewer)) {
                             outdatedCounter.incrementAndGet();
+                        }
+                        if (!locationValid) {
+                            invalidLocationCounter.incrementAndGet();
                         }
 
                         // Skip this check for now

--- a/src/main/java/no/rutebanken/anshar/data/VehicleActivities.java
+++ b/src/main/java/no/rutebanken/anshar/data/VehicleActivities.java
@@ -351,26 +351,28 @@ public class VehicleActivities extends SiriRepository<VehicleActivityStructure> 
 
                     if (isUpdated(existingChecksum, currentChecksum)) {
 
-                        boolean keep = (existing == null); //No existing data i.e. keep
+                        boolean isNewer = (existing == null); //No existing data i.e. keep
 
                         if (existing != null &&
                                 (activity.getRecordedAtTime() != null && existing.getRecordedAtTime() != null)) {
                             //Newer data has already been processed
-                            keep = activity.getRecordedAtTime().isAfter(existing.getRecordedAtTime());
+                            isNewer = activity.getRecordedAtTime().isAfter(existing.getRecordedAtTime());
                         }
 
                         long expiration = getExpiration(activity);
                         timingTracer.mark("getExpiration");
 
+                        boolean locationValid = isLocationValid(activity);
+                        timingTracer.mark("isLocationValid");
+
                         resolveContentMetrics(activity, expiration);
-                        if (expiration > 0 && keep) {
+                        if (expiration > 0 && isNewer && locationValid) {
                             changes.put(key, activity);
+                        } else if (!locationValid) {
+                            invalidLocationCounter.incrementAndGet();
                         } else {
                             outdatedCounter.incrementAndGet();
                         }
-
-                        if (!isLocationValid(activity)) {invalidLocationCounter.incrementAndGet();}
-                        timingTracer.mark("isLocationValid");
 
                         // Skip this check for now
                         if (!isActivityMeaningful(activity)) {notMeaningfulCounter.incrementAndGet();}

--- a/src/test/java/no/rutebanken/anshar/data/VehicleActivitiesTest.java
+++ b/src/test/java/no/rutebanken/anshar/data/VehicleActivitiesTest.java
@@ -116,6 +116,55 @@ public class VehicleActivitiesTest extends SpringBootBaseTest {
     }
 
     @Test
+    public void testZeroZeroLocationFilter() {
+        int previousSize = vehicleActivities.getAll().size();
+        VehicleActivityStructure element = createVehicleActivityStructure(
+                ZonedDateTime.now().plusMinutes(1), UUID.randomUUID().toString()
+        );
+        element.getMonitoredVehicleJourney().getVehicleLocation().setLatitude(BigDecimal.ZERO);
+        element.getMonitoredVehicleJourney().getVehicleLocation().setLongitude(BigDecimal.ZERO);
+
+        vehicleActivities.add("test", element);
+        assertEquals(previousSize, vehicleActivities.getAll().size(), "Vehicle with [0, 0]-location was added");
+    }
+
+    @Test
+    public void testZeroLatitudeFilter() {
+        int previousSize = vehicleActivities.getAll().size();
+        VehicleActivityStructure element = createVehicleActivityStructure(
+                ZonedDateTime.now().plusMinutes(1), UUID.randomUUID().toString()
+        );
+        element.getMonitoredVehicleJourney().getVehicleLocation().setLatitude(BigDecimal.ZERO);
+
+        vehicleActivities.add("test", element);
+        assertEquals(previousSize, vehicleActivities.getAll().size(), "Vehicle with latitude=0 was added");
+    }
+
+    @Test
+    public void testZeroLongitudeFilter() {
+        int previousSize = vehicleActivities.getAll().size();
+        VehicleActivityStructure element = createVehicleActivityStructure(
+                ZonedDateTime.now().plusMinutes(1), UUID.randomUUID().toString()
+        );
+        element.getMonitoredVehicleJourney().getVehicleLocation().setLongitude(BigDecimal.ZERO);
+
+        vehicleActivities.add("test", element);
+        assertEquals(previousSize, vehicleActivities.getAll().size(), "Vehicle with longitude=0 was added");
+    }
+
+    @Test
+    public void testNullVehicleLocationFilter() {
+        int previousSize = vehicleActivities.getAll().size();
+        VehicleActivityStructure element = createVehicleActivityStructure(
+                ZonedDateTime.now().plusMinutes(1), UUID.randomUUID().toString()
+        );
+        element.getMonitoredVehicleJourney().setVehicleLocation(null);
+
+        vehicleActivities.add("test", element);
+        assertEquals(previousSize, vehicleActivities.getAll().size(), "Vehicle with null location was added");
+    }
+
+    @Test
     public void testUpdatedVehicle() {
         int previousSize = vehicleActivities.getAll().size();
 


### PR DESCRIPTION
Actually remove vehicle positions with 0 lat or long from the live feed, instead of just reporting invalid positions.

dev notes:

* It might be that report-only is the intended behavior, but this has been submitted by an end user: 
<img width="292" height="633" alt="attachment1786426044611_50pct" src="https://github.com/user-attachments/assets/53dd23e8-c957-453f-9e0c-58d52c1f4ac6" />

* Vehicles in England or Brazil (say) may have actually valid exact 0 coordinates, but I think in general it is better to remove updates where any coordinate is == 0 (as opposed to both). In these (rare) cases, the next update should be processed as normal.

----

isLocationValid() already detected null/zero coordinates on VehicleMonitoring updates, but its result was only used to increment a metrics counter — the activity had already been unconditionally added to the changes map beforehand. This meant vehicles reported at 0N/0W (or with a zero-only lat or lon) were logged as invalid but still stored and served to clients.

Move the isLocationValid() check into the storage-gating condition so invalid-location activities are actually dropped.

Added regression tests covering 0/0, lat-only-zero, lon-only-zero, and null VehicleLocation.